### PR TITLE
feat(project): add command line script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 dmn-migration-utility
+
+## Usage
+
+```sh
+cd dmn-migration-utility
+npx . --input diagram.dmn --output migrated-diagram.dmn
+```

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const {
+  input,
+  output
+} = require('mri')(process.argv, {
+  alias: {
+    i: 'input',
+    o: 'output'
+  }
+});
+
+if (!input || !output) {
+  throw new Error('Missing --input or --output');
+}
+
+const fs = require('fs');
+
+const diagramXML = fs.readFileSync(input, 'utf8');
+
+const migrateDiagram = require('../src/migrateDiagram');
+
+migrateDiagram(diagramXML)
+  .then(outputXML => {
+    fs.writeFileSync(output, outputXML);
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,6 +1342,11 @@
         "saxen": "^8.1.0"
       }
     },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "dmn-migration-utility",
   "main": "src/migrateDiagram.js",
+  "bin": "bin/migrate",
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --reporter=spec --recursive test/spec"
@@ -24,7 +25,8 @@
   "dependencies": {
     "dmn-moddle": "^7.0.0",
     "ids": "^1.0.0",
-    "min-dash": "^3.5.2"
+    "min-dash": "^3.5.2",
+    "mri": "^1.1.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Use the script in bin/migrate to migrate diagrams
from command line, e.g.
`dmn-migration-utility -i diagram.dmn -o migrated.dmn`